### PR TITLE
Fix link underline styling for code elements, topic pages, and disclosure boxes

### DIFF
--- a/css/bjc.css
+++ b/css/bjc.css
@@ -286,7 +286,12 @@ table.remainders {
   width: 40%;
 }
 
-code {
+/* `a > code` repeats the base rule to beat Bootstrap's reboot, which has
+ * `a > code { color: inherit }` and would otherwise repaint block names inside
+ * a link with the link color. Code is code wherever it appears; the link is
+ * still marked by the surrounding link color and underline. */
+code,
+a > code {
   padding: 0px;
   color: #8b008b;
 }

--- a/llab/css/default.css
+++ b/llab/css/default.css
@@ -613,6 +613,26 @@ a.dropdown-item:not(.btn-primary):not(.btn-nav):visited {
   color: #3056AA;
 }
 
+/* For the same reason, drop the Bootstrap reboot underline: a topic page is
+ * almost entirely links, so underlining each one turns the page into a wall of
+ * rules rather than marking anything out. The list numbering, indentation and
+ * link color carry the affordance; the underline comes back on hover/focus.
+ * The "go to the course table of contents" link sits just above the topic
+ * divs rather than inside one, but it is part of the same page, so match it
+ * there too -- it keeps its underline on the vocab-index pages, which are
+ * prose and where it is the odd link out rather than the odd one in. */
+.topic a,
+.course_link:has(~ .topic) {
+  text-decoration: none;
+}
+
+.topic a:hover,
+.topic a:focus-visible,
+.course_link:has(~ .topic):hover,
+.course_link:has(~ .topic):focus-visible {
+  text-decoration: underline;
+}
+
 .course-link-list, .main-topic-link, .current-page-arrow {
   font-weight: bold;
   background-size: contain;
@@ -1350,6 +1370,21 @@ img.indent, div.indent {
   .page-feedback {
     display: none;
   }
+}
+
+/* A collapse toggle opens a disclosure on this page rather than going
+ * somewhere, so it doesn't read as a link: the ▸/▾ marker added below is what
+ * identifies it, and it changes with the state. Underline on hover/focus so
+ * the control is still obviously interactive.
+ * (<summary> on a <details> disclosure -- see .disclosure-heading -- is not an
+ * anchor, so the reboot never underlines it.) */
+a[data-bs-toggle="collapse"] {
+  text-decoration: none;
+}
+
+a[data-bs-toggle="collapse"]:hover,
+a[data-bs-toggle="collapse"]:focus-visible {
+  text-decoration: underline;
 }
 
 a[data-bs-toggle="collapse"]:not([aria-expanded="true"])::after,


### PR DESCRIPTION
## Fix link underline styling for code elements, topic pages, and disclosure boxes

Addresses three related link underline issues: `<code>` elements inside links were being repainted with the link color, topic pages were over-underlined due to nearly every element being a link, and disclosure toggle links were underlined despite not navigating anywhere.

## Changes

- **`a > code` color fix** (`css/bjc.css`): Added `a > code` to the existing `code` rule to override Bootstrap's reboot `a > code { color: inherit }`, which was repainting block names inside links with the link color instead of the expected `#8b008b`.
- **Topic page link underlines** (`llab/css/default.css`): Removed resting-state underlines from `.topic a` and the "go to course table of contents" link (scoped via `:has(~ .topic)`) since topic pages are almost entirely links. Underlines are restored on hover/focus. Vocab index pages retain standard underline behavior.
- **Disclosure toggle underlines** (`llab/css/default.css`): Removed resting-state underlines from `a[data-bs-toggle="collapse"]` since the ▸/▾ marker already identifies these as interactive controls. Underlines return on hover/focus.

## Visual Changes

| | Before | After |
|---|---|---|
| Topic page | [Before](https://www.superconductor.com/ticket_implementations/pQbFFBgpKzHc/artifacts/JqFcBNHPz8bF) | [After](https://www.superconductor.com/ticket_implementations/pQbFFBgpKzHc/artifacts/RFrJDMJ7RH76) |
| Disclosure boxes | [Before](https://www.superconductor.com/ticket_implementations/pQbFFBgpKzHc/artifacts/BJwKQFB67bN7) | [After](https://www.superconductor.com/ticket_implementations/pQbFFBgpKzHc/artifacts/Kk9KftQz7bMb) |

**Note for reviewers:** `<code>` inside ToC dropdown items will now render in purple (`#8b008b`) instead of the dropdown's default `#212529`. Contrast is fine (~7.6:1 on white) and it matches body text, but flag if you'd prefer to exempt `.dropdown-item`. See [ToC dropdown after](https://www.superconductor.com/ticket_implementations/pQbFFBgpKzHc/artifacts/kTtwGt97gLhm).

---

[Superconductor Ticket Implementation](https://www.superconductor.com/tickets/TTtTbbN9LKjm/implementations/pQbFFBgpKzHc) | [App Preview](https://www.superconductor.com/tickets/TTtTbbN9LKjm/implementations/pQbFFBgpKzHc/preview) | [Guided Review](https://www.superconductor.com/tickets/TTtTbbN9LKjm/implementations/pQbFFBgpKzHc?tab=guided_review)

<!-- created-by-superconductor -->